### PR TITLE
add class names to shinybox a tags, and filter

### DIFF
--- a/JS/jquery.shinybox.js
+++ b/JS/jquery.shinybox.js
@@ -36,7 +36,7 @@
         }];
 
         $window.resize(function (e) {
-            resizeOps.forEach(function(operation) {
+            resizeOps.forEach(function (operation) {
                 operation(e);
             });
         });
@@ -70,7 +70,7 @@
             verticalSwipeDisable: false
         };
 
-        function Shinybox (element, options) {
+        function Shinybox(element, options) {
             var self = this instanceof Shinybox ? this : {};
             var settings = $.extend({}, defaultOptions, options);
             var selector = element.selector;
@@ -96,13 +96,17 @@
                     self.ui.openWithSlide(settings.initialIndexOnArray);
                 };
             } else {
-                function openShinyboxOnClick (e) {
+                function openShinyboxOnClick(e) {
                     if (e.target.parentNode.className === 'slide current') {
                         return false;
                     }
 
                     e.preventDefault();
                     e.stopPropagation();
+
+                    // check for currently selected filter and grab its classname
+                    var filters = $('.filter-item').filter('.checked')
+                    var filterTerm = filters.attr("data-filter")
 
                     self.ui && self.ui.destroy();
 
@@ -122,7 +126,12 @@
                     if (relVal && relVal !== 'nofollow') {
                         $slideElements = $selectedElements.filter('[' + relType + '="' + relVal + '"]');
                     } else {
-                        $slideElements = $(selector);
+                        // check filter term (can be undefined) and apply it to ALSO filter shinybox
+                        if (filterTerm !== undefined) {
+                            $slideElements = $(selector + filterTerm);
+                        } else {
+                            $slideElements = $(selector);
+                        }
                     }
 
                     // Generate slides from DOM elements and initialize UI
@@ -131,15 +140,15 @@
                     });
                     var index = typeof $this.data("dom-index") !== "undefined" ? $this.data("dom-index") - $(filteredSlides[0]).data("dom-index") : $(filteredSlides).index($this);
 
-                    var slides = Array.prototype.map.call(filteredSlides, function(slideElement) {
-                            var $slideElement = $(slideElement);
-                            return {
-                                href: $slideElement.attr('href') || null,
-                                title: $slideElement.attr('title') || null,
-                                caption: $slideElement.attr('caption') || null,
-                                srcset: $slideElement.attr('data-hrefs') || null
-                            };
-                        });
+                    var slides = Array.prototype.map.call(filteredSlides, function (slideElement) {
+                        var $slideElement = $(slideElement);
+                        return {
+                            href: $slideElement.attr('href') || null,
+                            title: $slideElement.attr('title') || null,
+                            caption: $slideElement.attr('caption') || null,
+                            srcset: $slideElement.attr('data-hrefs') || null
+                        };
+                    });
 
                     eventCatcher = $(e.target);
                     self.ui = new UI(slides, settings);
@@ -169,7 +178,7 @@
         /**
          * UI Manager Class
          */
-        function UI (slides, settings) {
+        function UI(slides, settings) {
             this.slides = slides;
             this.settings = settings;
             this.currentX = 0;
@@ -184,10 +193,10 @@
 
             this.closeButton = $('<a class="shinybox-close" />');
             this.captionBox = $('<div class="shinybox-caption captionTitle"></div>');
-            
+
             this.caption = $('<p class="caption"></p>');
             this.title = $('<p class="title"></p>');
-            
+
             this.captionBox.append(this.title, this.caption);
 
             this.navigationContainer = $('<div class="navigationContainer"></div>')
@@ -203,7 +212,7 @@
             if (isMobile) {
                 this.overlay.addClass("mobile-view");
             }
-            
+
             if (this.settings.noTitleCaptionBox) {
                 this.overlay.addClass("noTitleCaptionBox");
             }
@@ -277,7 +286,7 @@
          * Touch navigation
          */
         UI.prototype.setupGestureNavigation = function () {
-            if(!isTouch) {
+            if (!isTouch) {
                 return;
             }
 
@@ -292,7 +301,7 @@
             var vSwipMinDistance = 50;
             var startCoords = {};
             var endCoords = {};
-            
+
             var touchMoveEventHandler = function (e) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -331,10 +340,10 @@
                 }
             };
 
-            
+
             var touchPoints = null;
             this.overlay.on('touchstart', function (e) {
-                if(e.originalEvent.touches && e.originalEvent.touches.length > 1) {
+                if (e.originalEvent.touches && e.originalEvent.touches.length > 1) {
                     $(this).off('touchmove', touchMoveEventHandler);
                     return true;
                 }
@@ -353,7 +362,7 @@
             });
 
             this.overlay.on('touchend', function (e) {
-                if(e.originalEvent.touches && e.originalEvent.touches.length > 1) {
+                if (e.originalEvent.touches && e.originalEvent.touches.length > 1) {
                     $(this).off('touchmove', touchMoveEventHandler);
                     return true;
                 }
@@ -386,10 +395,10 @@
                     }
                 } else if (hSwipe) {
                     hSwipe = false;
-                    if( hDistance >= hSwipMinDistance && hDistance >= hDistanceLast && hasOneTouchPoint) {
+                    if (hDistance >= hSwipMinDistance && hDistance >= hDistanceLast && hasOneTouchPoint) {
                         // swipeLeft
                         self.getPrev();
-                    } else if ( hDistance <= -hSwipMinDistance && hDistance <= hDistanceLast && hasOneTouchPoint) {
+                    } else if (hDistance <= -hSwipMinDistance && hDistance <= hDistanceLast && hasOneTouchPoint) {
                         // swipeRight
                         self.getNext();
                     }
@@ -406,7 +415,7 @@
         UI.prototype.setupKeyboardNavigation = function () {
             var self = this;
             this._keyDownEvent = function (e) {
-                if(!self.isOpen) {
+                if (!self.isOpen) {
                     return true;
                 }
 
@@ -434,7 +443,7 @@
          */
         UI.prototype.setupWindowResizeEvent = function () {
             var self = this;
-            this.resizeIndex = resizeOps.push(function() {
+            this.resizeIndex = resizeOps.push(function () {
                 self.updateDimensions();
             }) - 1;
         };
@@ -488,7 +497,7 @@
                 this.slider.fadeIn();
             }
 
-            if(!this.settings.loopAtEnd) {
+            if (!this.settings.loopAtEnd) {
                 this.prevButton.removeClass('disabled');
                 this.nextButton.removeClass('disabled');
                 if (index === 0) {
@@ -531,10 +540,10 @@
             this.setSlide(index);
             this.preloadMedia(index);
 
-            if(this.settings.loopAtEnd || nextIndex !== 0) {
+            if (this.settings.loopAtEnd || nextIndex !== 0) {
                 this.preloadMedia(nextIndex);
             }
-            if(this.settings.loopAtEnd || prevIndex !== this.slides.length - 1) {
+            if (this.settings.loopAtEnd || prevIndex !== this.slides.length - 1) {
                 this.preloadMedia(prevIndex);
             }
         };
@@ -556,7 +565,7 @@
             } else {
                 this.overlay.addClass('rightSpring');
                 setTimeout(function () {
-                   self.overlay.removeClass('rightSpring');
+                    self.overlay.removeClass('rightSpring');
                 }, 500);
             }
         };
@@ -588,7 +597,7 @@
          * If slide contains an iframe, refresh it before exiting slide.
          * to have zero delay when the slide is opened next time
          */
-        UI.prototype.resetIframeInSlide = function(index) {
+        UI.prototype.resetIframeInSlide = function (index) {
             index = this.validateIndex(index);
 
             var iframeInSlide = this.slideElements.eq(index).contents().find('iframe');
@@ -631,7 +640,7 @@
                 srcset = this.slides[index].srcset;
             }
 
-            if(!src) {
+            if (!src) {
                 return false;
             }
 
@@ -807,7 +816,7 @@
         $.fn.shinybox = function (options) {
             var instance = this.data('_shinybox');
 
-            if(instance && options === 'destroy') {
+            if (instance && options === 'destroy') {
                 instance.destroy();
                 return this.removeData('_shinybox');
             }
@@ -823,7 +832,7 @@
         return Shinybox;
 
         // Utilities
-        function noop() {}
+        function noop() { }
 
         function checkForCssTransitionSupport() {
             var prefixes = ["transition", "WebkitTransition", "MozTransition", "OTransition", "msTransition", "KhtmlTransition"];

--- a/index.html
+++ b/index.html
@@ -5,671 +5,624 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Marcy Gooberman is a designer and illustrator living in Brooklyn.">
-    <meta name="keywords" content="Marcy Gooberman, Marcy Gooberman Graphic Design, Marcy Gooberman facebook, Marcy Gooberman graphic design, Marcy Gooberman design, Marcy Gooberman linkedin, marcygoob, MarcyGoob, Marcy Gooberman email, Marcy Gooberman Illustration, marcy gooberman illustration, Marcy Gooberman Design, Marcy Gooberman Graphic Designer, Graphic Design, Graphic Designer, Marcy Gooberman Illustrator, Marcy Gooberman Artist">
+    <meta name="keywords"
+        content="Marcy Gooberman, Marcy Gooberman Graphic Design, Marcy Gooberman facebook, Marcy Gooberman graphic design, Marcy Gooberman design, Marcy Gooberman linkedin, marcygoob, MarcyGoob, Marcy Gooberman email, Marcy Gooberman Illustration, marcy gooberman illustration, Marcy Gooberman Design, Marcy Gooberman Graphic Designer, Graphic Design, Graphic Designer, Marcy Gooberman Illustrator, Marcy Gooberman Artist">
     <meta name="author" content="Marcy Gooberman">
     <meta name="Robots" content="index,follow, all">
     <meta name="google-site-verification" content="1_UMZuUtlWZnhmPqH7e3rgIgYKeR-H8BMwH4Vmgh1NM" />
     <title>Marcy Gooberman</title>
     <link rel="stylesheet" href="styles.css" type="text/css" media="all">
     <link rel="stylesheet" href="shinybox.css" type="text/css" media="all">
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;300;400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;300;400;500;700;900&display=swap"
+        rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Cousine:wght@400;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;700;900&display=swap" rel="stylesheet">
 </head>
 
 <body>
-         
+
 
     <h1>
-        Marcy Gooberman is a designer and illustrator in Brooklyn available for freelance work.<br><br>&#128140 marcygoob@gmail.com<br><a href="instagram.com/marcygoob">&#128248 @marcygoob<br></a>
+        Marcy Gooberman is a designer and illustrator in Brooklyn available for freelance work.<br><br>&#128140
+        marcygoob@gmail.com<br><a href="instagram.com/marcygoob">&#128248 @marcygoob<br></a>
     </h1>
 
 
-        <nav id="filter" class="filters">
-            
-            <ul class="filter-list" data-filter-group="subject">
-                <li><a href="javascript:void(0)" data-filter=".branding">Branding</a></li>
-                <li><a href="javascript:void(0)" data-filter=".social">Social Media</a></li>
-                <li><a href="javascript:void(0)" data-filter=".illustration">Illustration</a></li>
-                <li><a href="javascript:void(0)" data-filter=".print">Print</a></li>
-                
-                <li><a href="javascript:void(0)" data-filter=".motion">Motion Graphics</a></li>
-                
-                <li><a href="javascript:void(0)" data-filter=".web">Web</a></li>
-                
-            </ul><!-- .subject -->
-            
-        </nav><!-- .filters -->
-
-        <div class="courses">
-        
-
-<!-- period pandemic --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Blume_1.png"
-                                class="shinybox" 
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_1.png" alt="">
-                                Blume
-                            </a>
-
-                        </article>
-
-  <!-- suraj posters --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Suraj_Patel_3.jpg"
-                                class="shinybox" 
-                                title="Suraj Patel for Congress">
-                                <img src="images/Marcy_Gooberman_Suraj_Patel_3.jpg" alt="">
-                                Suraj Patel for Congress
-                            </a>
-                        </article>
-
-  <!-- marcy & peggy --><article class="course illustration">
-                            <a href="images/Marcy_Gooberman_Personal_2.png"
-                                class="shinybox"                                 
-                                title="Personal Work">      
-                                <img src="images/Marcy_Gooberman_Personal_2.png" alt="">
-                                Personal Work
-                            </a>    
-                        </article>
-
-       <!-- dog riso --><article class="course illustration print">
-                            <a href="images/Marcy_Gooberman_Personal_5.jpg"
-                                class="shinybox"                                 
-                                title="Personal Work">
-                                <img src="images/Marcy_Gooberman_Personal_5.jpg" alt="">
-                                Personal Work
-                            </a>
-                        </article>
-
-   <!-- one day left --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Best_Kept_Secret_1.gif"
-                                class="shinybox"
-                                title="Best Kept Secret">
-                                <img src="images/Marcy_Gooberman_Best_Kept_Secret_1.gif" alt="">
-                                Best Kept Secret
-                            </a>
-                        </article>
-
-     <!-- flash sale --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Blume_2.gif"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_2.gif" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-      <!-- blume box --><article class="course motion illustration">
-                            <a href="images/Marcy_Gooberman_Blume_3.gif"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_3.gif" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-     <!-- foundation --><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_5.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_5.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article>
-
- <!-- back to school --><article class="course print illustration">
-                            <a href="images/Marcy_Gooberman_Blume_4.jpg"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_4.jpg" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-   <!-- make me feel --><article class="course social">
-                            <a href="images/Marcy_Gooberman_tabu_6.png"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_6.png" alt="">
-                                tabú
-                            </a>
-                        </article>
-
-       <!-- crunches --><article class="course social motion illustration">
-                            <a href="images/Marcy_Gooberman_WW_2.gif"
-                                class="shinybox"
-                                title="Weight Watchers">
-                                <img src="images/Marcy_Gooberman_WW_2.gif" alt="">
-                                Weight Watchers
-                            </a>
-                        </article>                                                
-
-<!-- m cyclists --><article class="course branding">
-                            <a href="images/Marcy_Gooberman_Menstrual_Cyclists_1.png"
-                                class="shinybox"
-                                title="Menstrual Cyclists">
-                                <img src="images/Marcy_Gooberman_Menstrual_Cyclists_1.png" alt="">
-                                Menstrual Cyclists
-                            </a>
-                        </article>
-
-          <!-- iskra --><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_6.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_6.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article> 
-
-      <!-- dolly vid --><article class="course motion">
-                            <a href="images/Marcy_Gooberman_NYPR_1.gif"
-                                class="shinybox"
-                                title="Dolly Parton's America by NY Public Radio">
-                                <img src="images/Marcy_Gooberman_NYPR_1.gif" alt="">
-                                Dolly Parton's America by NY Public Radio
-                            </a>
-                        </article>  
-
-  <!-- alyson stoner --><article class="course social">
-                            <a href="images/Marcy_Gooberman_tabu_5.png"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_5.png" alt="">
-                                tabú
-                            </a>
-                        </article>                                              
-                        
-     <!-- dumto logo --><article class="course branding">
-                            <a href="images/Marcy_Gooberman_DUMTO_1.png"
-                                class="shinybox"
-                                title="DUMTO Brooklyn">
-                                <img src="images/Marcy_Gooberman_DUMTO_1.png" alt="">
-                                DUMTO Brooklyn
-                            </a>     
-                        </article>                                                                      
-  <!-- school photos --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Blume_12.png"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_12.png" alt="">
-                                Blume
-                            </a>
-                        </article>
-
- <!-- subway posters --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Suraj_Patel_2.jpg"
-                                class="shinybox"
-                                title="Suraj Patel for Congress">
-                                <img src="images/Marcy_Gooberman_Suraj_Patel_2.jpg" alt="">
-                                Suraj Patel for Congress
-                            </a>
-                        </article>
-
-  <!-- exercise ball --><article class="course illustration motion">
-                            <a href="images/Marcy_Gooberman_Cosmo_Sex_2.gif"
-                                class="shinybox"
-                                title="Cosmopolitan.com">
-                                <img src="images/Marcy_Gooberman_Cosmo_Sex_2.gif" alt="">
-                                Cosmopolitan.com
-                            </a>    
-                        </article>                       
-
-       <!-- stickers --><article class="course print illustration">
-                            <a href="images/Marcy_Gooberman_Blume_7.jpg"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_7.jpg" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-         <!-- uterus --><article class="course motion illustration">
-                            <a href="images/Marcy_Gooberman_Blume_8.gif"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_8.gif" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-<!-- inside brochure --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Hello_Alfred_2.png"
-                                
-                                title="Hello Alfred">
-                                <img src="images/Marcy_Gooberman_Hello_Alfred_2.png" alt="">
-                                Hello Alfred
-                            </a>  
-                        </article>
-
-            <!-- iud --><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_3.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_3.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article>
-
-<!-- mini daydreamer --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Blume_9.jpg"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_9.jpg" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-       <!-- lipstick --><article class="course illustration">
-                            <a href="images/Marcy_Gooberman_tabu_4.jpg"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_4.jpg" alt="">
-                                tabú
-                            </a>
-                        </article>                        
-
-       <!-- fts logo --><article class="course branding">
-                            <a href="images/Marcy_Gooberman_FTS_1.png"
-                                class="shinybox"
-                                title="Friend That Spends">
-                                <img src="images/Marcy_Gooberman_FTS_1.png" alt="">
-                                Friend That Spends
-                            </a>
-                        </article>
-
-   <!-- tarana burke --><article class="course social">
-                            <a href="images/Marcy_Gooberman_tabu_9.png"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_9.png" alt="">
-                                tabú
-                            </a>
-                        </article>  
-
-      <!-- 24 states --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Blume_10.png"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_10.png" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-       <!-- butthole --><article class="course illustration motion">
-                            <a href="images/Marcy_Gooberman_Cosmo_Sex_1.gif"
-                                class="shinybox"
-                                title="Cosmopolitan.com">
-                                <img src="images/Marcy_Gooberman_Cosmo_Sex_1.gif" alt="">
-                                Cosmopolitan.com
-                            </a>  
-                        </article>               
-
-           <!-- mimi --><article class="course motion illustration">
-                            <a href="images/Marcy_Gooberman_Mizo_1.gif"
-                                class="shinybox"
-                                title="Mizo Productions">
-                                <img src="images/Marcy_Gooberman_Mizo_1.gif" alt="">
-                                Mizo Productions                            
-                            </a>
-                        </article>
-
-    <!-- highlighter --><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_4.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_4.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article>
-
- <!-- sexual assault --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Blume_11.png"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_11.png" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-          <!-- dumto --><article class="course illustration print">
-                            <a href="images/Marcy_Gooberman_DUMTO_2.png"
-                                class="shinybox"
-                                title="DUMTO Brooklyn">
-                                <img src="images/Marcy_Gooberman_DUMTO_2.png" alt="">
-                                DUMTO Brooklyn
-                            </a>    
-                        </article>
-
-       <!-- wishlist --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Best_Kept_Secret_3.gif"
-                                class="shinybox"
-                                title="Best Kept Secret">
-                                <img src="images/Marcy_Gooberman_Best_Kept_Secret_3.gif" alt="">
-                                Best Kept Secret
-                            </a>
-                        </article>
-
-          <!-- whirl --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Blume_15.jpg"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_15.jpg" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-      <!-- halloween --><article class="course illustration motion">
-                            <a href="images/Marcy_Gooberman_Cosmo_Sex_3.gif"
-                                class="shinybox"
-                                title="Cosmopolitan.com">
-                                <img src="images/Marcy_Gooberman_Cosmo_Sex_3.gif" alt="">
-                                Cosmopolitan.com
-                            </a>  
-                        </article>
-
-      <!-- naked man --><article class="course illustration">
-                            <a href="images/Marcy_Gooberman_tabu_1.jpg"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_1.jpg" alt="">
-                                tabú
-                            </a>
-                        </article>                        
-
-         <!-- airhug --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Blume_16.jpg"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_16.jpg" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-         <!-- selfie --><article class="course illustration">
-                            <a href="images/Marcy_Gooberman_Personal_3.jpg"
-                            class="shinybox"
-                            title="Personal Work">
-                            <img src="images/Marcy_Gooberman_Personal_3.jpg" alt="">
-                                Personal Work
-                            </a>
-                        </article>
-
-      <!-- equal pay --><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_1.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_1.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article>
-
-          <!-- disco --><article class="course illustration motion">
-                            <a href="images/Marcy_Gooberman_Cosmo_Sex_5.gif"
-                                class="shinybox"
-                                title="Cosmopolitan.com">
-                                <img src="images/Marcy_Gooberman_Cosmo_Sex_5.gif" alt="">
-                                Cosmopolitan.com
-                            </a>  
-                        </article>
-
-    <!-- lena waithe --><article class="course social">
-                            <a href="images/Marcy_Gooberman_tabu_8.png"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_8.png" alt="">
-                                tabú
-                            </a>
-                        </article>
-
- <!-- back to school --><article class="course web">
-                            <a href="images/Marcy_Gooberman_Blume_19.png"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_19.png" alt="">
-                                Blume
-                            </a>
-                        </article>                        
-
-<!-- lazy girl hacks --><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_2.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_2.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article>
-
-        <!-- cloud 9 --><article class="course motion illustration">
-                            <a href="images/Marcy_Gooberman_Blume_17.gif"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_17.gif" alt="">
-                                Blume
-                            </a>
-                        </article>
-
- <!-- brochure cover --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Hello_Alfred_1.png"
-                                class="shinybox"
-                                title="Hello Alfred">
-                                <img src="images/Marcy_Gooberman_Hello_Alfred_1.png" alt="">
-                                Hello Alfred
-                            </a>
-                        </article>
-
-           <!-- gyno --><article class="course illustration">
-                            <a href="images/Marcy_Gooberman_tabu_2.jpg"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_2.jpg" alt="">
-                                tabú
-                            </a>
-                        </article>                       
-
-   <!-- suraj condom --><article class="course print illustration">
-                            <a href="images/Marcy_Gooberman_Suraj_Patel_1.gif"
-                                class="shinybox"
-                                title="Suraj Patel for Congress">
-                                <img src="images/Marcy_Gooberman_Suraj_Patel_1.gif" alt="">
-                                Suraj Patel for Congress
-                            </a>
-                        </article>
-
-         <!-- hug me --><article class="course motion illustration">
-                            <a href="images/Marcy_Gooberman_Blume_18.gif"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_18.gif" alt="">
-                                Blume
-                            </a>
-                        </article>                         
-
-  <!-- self care bag --><article class="course print">
-                           <a href="images/Marcy_Gooberman_Blume_5.jpg"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_5.jpg" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-  <!-- shopping tips --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Best_Kept_Secret_2.gif"
-                                class="shinybox"
-                                title="Best Kept Secret">
-                                <img src="images/Marcy_Gooberman_Best_Kept_Secret_2.gif" alt="">
-                                Best Kept Secret
-                            </a>
-                        </article>
-
-<!-- self care covid --><article class="course social illustration">
-                            <a href="images/Marcy_Gooberman_Blume_14.png"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_14.png" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-      <!-- ballerina --><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_8.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_8.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article>
-
-           <!-- zora --><article class="course motion illustration">
-                            <a href="images/Marcy_Gooberman_Mizo_2.gif"
-                                class="shinybox"
-                                title="Mizo Productions">
-                                <img src="images/Marcy_Gooberman_Mizo_2.gif" alt="">
-                                Mizo Productions                            
-                            </a>
-                        </article>
-
-          <!-- larry --><article class="course motion illustration">
-                            <a href="images/Marcy_Gooberman_Personal_1.gif"
-                                class="shinybox"
-                                title="Personal Work">
-                                <img src="images/Marcy_Gooberman_Personal_1.gif" alt="">
-                                Personal Work
-                            </a>
-                        </article>
-
-    <!-- help people --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Blume_13.png"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_13.png" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-     <!-- dolly riso --><article class="course illustration print">
-                            <a href="images/Marcy_Gooberman_Personal_6.jpg"
-                                class="shinybox"
-                                title="Personal Work">
-                                <img src="images/Marcy_Gooberman_Personal_6.jpg" alt="">
-                                Personal Work
-                            </a>
-                        </article>
-
-         <!-- tshirt --><article class="course print">
-                            <a href="images/Marcy_Gooberman_Blume_6.jpg"
-                                class="shinybox"
-                                title="Blume">
-                                <img src="images/Marcy_Gooberman_Blume_6.jpg" alt="">
-                                Blume
-                            </a>
-                        </article>
-
-     <!-- greenspace --><article class="course print">
-                            <a href="images/Marcy_Gooberman_NYPR_2.png"
-                                class="shinybox"
-                                title="The Greene Space by NY Public Radio">
-                                <img src="images/Marcy_Gooberman_NYPR_2.png" alt="">
-                                The Greene Space by NY Public Radio
-                            </a>
-                        </article>
-
-      <!-- olson twins--><article class="course motion social">
-                            <a href="images/Marcy_Gooberman_Cosmo_Snap_7.gif"
-                                class="shinybox"
-                                title="Cosmopolitan Snapchat Discover">
-                                <img src="images/Marcy_Gooberman_Cosmo_Snap_7.gif" alt="">
-                                Cosmopolitan Snapchat Discover
-                            </a>
-                        </article>
-
-     <!-- gravitatas --><article class="course branding">
-                            <a href="images/Marcy_Gooberman_gravitatas_1.png"
-                                class="shinybox"
-                                title="Gravitatas">
-                                <img src="images/Marcy_Gooberman_gravitatas_1.png" alt="">
-                                Gravitatas
-                            </a>
-                        </article>
-
-    <!-- period pain --><article class="course illustration">
-                            <a href="images/Marcy_Gooberman_tabu_3.jpg"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_3.jpg" alt="">
-                                tabú
-                            </a>
-                        </article>
-
-       <!-- goob  --><article class="course web branding">
-                            <a href="images/Marcy_Gooberman_Personal_7.gif"
-                                class="shinybox"
-                                title="Personal Work">
-                                <img src="images/Marcy_Gooberman_Personal_7.gif" alt="">
-                                Personal Work
-                            </a>
-                        </article>
-
-<!-- toilet paper --><article class="course social">
-                            <a href="images/Marcy_Gooberman_Hello_Alfred_3.gif"
-                                class="shinybox"
-                                title="Hello Alfred">
-                                <img src="images/Marcy_Gooberman_Hello_Alfred_3.gif" alt="">
-                                Hello Alfred
-                            </a>
-                        </article>
-    
-<!-- oval office --><article class="course illustration motion">
-                            <a href="images/Marcy_Gooberman_Cosmo_Sex_4.gif"
-                                class="shinybox"
-                                title="Cosmopolitan.com">
-                                <img src="images/Marcy_Gooberman_Cosmo_Sex_4.gif" alt="">
-                                Cosmopolitan.com
-                            </a>  
-                        </article>
-
-          <!-- squat --><article class="course social motion illustration">
-                            <a href="images/Marcy_Gooberman_WW_1.gif"
-                                class="shinybox"
-                                title="Weight Watchers">
-                                <img src="images/Marcy_Gooberman_WW_1.gif" alt="">
-                                Weight Watchers
-                            </a>
-                        </article>
-
-        <!-- cardi b --><article class="course social">
-                            <a href="images/Marcy_Gooberman_tabu_7.png"
-                                class="shinybox"
-                                title="tabú">
-                                <img src="images/Marcy_Gooberman_tabu_7.png" alt="">
-                                tabú
-                            </a>
-                        </article>                        
-
-
-                                                        
-            </div>
-
- 
+    <nav id="filter" class="filters">
+
+        <ul class="filter-list" data-filter-group="subject">
+            <li><a href="javascript:void(0)" class="filter-item" data-filter=".branding">Branding</a></li>
+            <li><a href="javascript:void(0)" class="filter-item" data-filter=".social">Social Media</a></li>
+            <li><a href="javascript:void(0)" class="filter-item" data-filter=".illustration">Illustration</a></li>
+            <li><a href="javascript:void(0)" class="filter-item" data-filter=".print">Print</a></li>
+
+            <li><a href="javascript:void(0)" class="filter-item" data-filter=".motion">Motion Graphics</a></li>
+
+            <li><a href="javascript:void(0)" class="filter-item" data-filter=".web">Web</a></li>
+
+        </ul><!-- .subject -->
+
+    </nav><!-- .filters -->
+
+    <div class="courses">
+
+
+        <!-- period pandemic -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Blume_1.png" class="shinybox social" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_1.png" alt="">
+                Blume
+            </a>
+
+        </article>
+
+        <!-- suraj posters -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Suraj_Patel_3.jpg" class="shinybox print" title="Suraj Patel for Congress">
+                <img src="images/Marcy_Gooberman_Suraj_Patel_3.jpg" alt="">
+                Suraj Patel for Congress
+            </a>
+        </article>
+
+        <!-- marcy & peggy -->
+        <article class="course illustration">
+            <a href="images/Marcy_Gooberman_Personal_2.png" class="shinybox illustration" title="Personal Work">
+                <img src="images/Marcy_Gooberman_Personal_2.png" alt="">
+                Personal Work
+            </a>
+        </article>
+
+        <!-- dog riso -->
+        <article class="course illustration print">
+            <a href="images/Marcy_Gooberman_Personal_5.jpg" class="shinybox print illustration" title=" Personal Work">
+                <img src="images/Marcy_Gooberman_Personal_5.jpg" alt="">
+                Personal Work
+            </a>
+        </article>
+
+        <!-- one day left -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Best_Kept_Secret_1.gif" class="shinybox social" title="Best Kept Secret">
+                <img src="images/Marcy_Gooberman_Best_Kept_Secret_1.gif" alt="">
+                Best Kept Secret
+            </a>
+        </article>
+
+        <!-- flash sale -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Blume_2.gif" class="shinybox social" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_2.gif" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- blume box -->
+        <article class="course motion illustration">
+            <a href="images/Marcy_Gooberman_Blume_3.gif" class="shinybox motion illustration" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_3.gif" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- foundation -->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_5.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_5.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- back to school -->
+        <article class="course print illustration">
+            <a href="images/Marcy_Gooberman_Blume_4.jpg" class="shinybox print illustration" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_4.jpg" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- make me feel -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_tabu_6.png" class="shinybox social" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_6.png" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- crunches -->
+        <article class="course social motion illustration">
+            <a href="images/Marcy_Gooberman_WW_2.gif" class="shinybox social motion illustration"
+                title="Weight Watchers">
+                <img src="images/Marcy_Gooberman_WW_2.gif" alt="">
+                Weight Watchers
+            </a>
+        </article>
+
+        <!-- m cyclists -->
+        <article class="course branding">
+            <a href="images/Marcy_Gooberman_Menstrual_Cyclists_1.png" class="shinybox branding"
+                title="Menstrual Cyclists">
+                <img src="images/Marcy_Gooberman_Menstrual_Cyclists_1.png" alt="">
+                Menstrual Cyclists
+            </a>
+        </article>
+
+        <!-- iskra -->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_6.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_6.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- dolly vid -->
+        <article class="course motion">
+            <a href="images/Marcy_Gooberman_NYPR_1.gif" class="shinybox motion"
+                title="Dolly Parton's America by NY Public Radio">
+                <img src="images/Marcy_Gooberman_NYPR_1.gif" alt="">
+                Dolly Parton's America by NY Public Radio
+            </a>
+        </article>
+
+        <!-- alyson stoner -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_tabu_5.png" class="shinybox social" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_5.png" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- dumto logo -->
+        <article class="course branding">
+            <a href="images/Marcy_Gooberman_DUMTO_1.png" class="shinybox branding" title="DUMTO Brooklyn">
+                <img src="images/Marcy_Gooberman_DUMTO_1.png" alt="">
+                DUMTO Brooklyn
+            </a>
+        </article>
+        <!-- school photos -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Blume_12.png" class="shinybox social" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_12.png" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- subway posters -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Suraj_Patel_2.jpg" class="shinybox print" title="Suraj Patel for Congress">
+                <img src="images/Marcy_Gooberman_Suraj_Patel_2.jpg" alt="">
+                Suraj Patel for Congress
+            </a>
+        </article>
+
+        <!-- exercise ball -->
+        <article class="course illustration motion">
+            <a href="images/Marcy_Gooberman_Cosmo_Sex_2.gif" class="shinybox illustration motion"
+                title="Cosmopolitan.com">
+                <img src="images/Marcy_Gooberman_Cosmo_Sex_2.gif" alt="">
+                Cosmopolitan.com
+            </a>
+        </article>
+
+        <!-- stickers -->
+        <article class="course print illustration">
+            <a href="images/Marcy_Gooberman_Blume_7.jpg" class="shinybox print illustration" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_7.jpg" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- uterus -->
+        <article class="course motion illustration">
+            <a href="images/Marcy_Gooberman_Blume_8.gif" class="shinybox motion illustration" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_8.gif" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- inside brochure -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Hello_Alfred_2.png" title="Hello Alfred" class="shinybox print">
+                <img src="images/Marcy_Gooberman_Hello_Alfred_2.png" alt="">
+                Hello Alfred
+            </a>
+        </article>
+
+        <!-- iud -->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_3.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_3.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- mini daydreamer -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Blume_9.jpg" class="shinybox print" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_9.jpg" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- lipstick -->
+        <article class="course illustration">
+            <a href="images/Marcy_Gooberman_tabu_4.jpg" class="shinybox illustration" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_4.jpg" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- fts logo -->
+        <article class="course branding">
+            <a href="images/Marcy_Gooberman_FTS_1.png" class="shinybox branding" title="Friend That Spends">
+                <img src="images/Marcy_Gooberman_FTS_1.png" alt="">
+                Friend That Spends
+            </a>
+        </article>
+
+        <!-- tarana burke -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_tabu_9.png" class="shinybox social" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_9.png" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- 24 states -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Blume_10.png" class="shinybox social" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_10.png" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- butthole -->
+        <article class="course illustration motion">
+            <a href="images/Marcy_Gooberman_Cosmo_Sex_1.gif" class="shinybox illustration motion"
+                title="Cosmopolitan.com">
+                <img src="images/Marcy_Gooberman_Cosmo_Sex_1.gif" alt="">
+                Cosmopolitan.com
+            </a>
+        </article>
+
+        <!-- mimi -->
+        <article class="course motion illustration">
+            <a href="images/Marcy_Gooberman_Mizo_1.gif" class="shinybox motion illustration" title="Mizo Productions">
+                <img src="images/Marcy_Gooberman_Mizo_1.gif" alt="">
+                Mizo Productions
+            </a>
+        </article>
+
+        <!-- highlighter -->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_4.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_4.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- sexual assault -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Blume_11.png" class="shinybox social" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_11.png" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- dumto -->
+        <article class="course illustration print">
+            <a href="images/Marcy_Gooberman_DUMTO_2.png" class="shinybox illustration print" title="DUMTO Brooklyn">
+                <img src="images/Marcy_Gooberman_DUMTO_2.png" alt="">
+                DUMTO Brooklyn
+            </a>
+        </article>
+
+        <!-- wishlist -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Best_Kept_Secret_3.gif" class="shinybox social" title="Best Kept Secret">
+                <img src="images/Marcy_Gooberman_Best_Kept_Secret_3.gif" alt="">
+                Best Kept Secret
+            </a>
+        </article>
+
+        <!-- whirl -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Blume_15.jpg" class="shinybox print" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_15.jpg" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- halloween -->
+        <article class="course illustration motion">
+            <a href="images/Marcy_Gooberman_Cosmo_Sex_3.gif" class="shinybox illustration motion"
+                title="Cosmopolitan.com">
+                <img src="images/Marcy_Gooberman_Cosmo_Sex_3.gif" alt="">
+                Cosmopolitan.com
+            </a>
+        </article>
+
+        <!-- naked man -->
+        <article class="course illustration">
+            <a href="images/Marcy_Gooberman_tabu_1.jpg" class="shinybox illustration" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_1.jpg" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- airhug -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Blume_16.jpg" class="shinybox print" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_16.jpg" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- selfie -->
+        <article class="course illustration">
+            <a href="images/Marcy_Gooberman_Personal_3.jpg" class="shinybox illustration" title="Personal Work">
+                <img src="images/Marcy_Gooberman_Personal_3.jpg" alt="">
+                Personal Work
+            </a>
+        </article>
+
+        <!-- equal pay -->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_1.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_1.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- disco -->
+        <article class="course illustration motion">
+            <a href="images/Marcy_Gooberman_Cosmo_Sex_5.gif" class="shinybox illustration motion"
+                title="Cosmopolitan.com">
+                <img src="images/Marcy_Gooberman_Cosmo_Sex_5.gif" alt="">
+                Cosmopolitan.com
+            </a>
+        </article>
+
+        <!-- lena waithe -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_tabu_8.png" class="shinybox social" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_8.png" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- back to school -->
+        <article class="course web">
+            <a href="images/Marcy_Gooberman_Blume_19.png" class="shinybox web" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_19.png" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- lazy girl hacks -->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_2.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_2.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- cloud 9 -->
+        <article class="course motion illustration">
+            <a href="images/Marcy_Gooberman_Blume_17.gif" class="shinybox motion illustration" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_17.gif" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- brochure cover -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Hello_Alfred_1.png" class="shinybox print" title="Hello Alfred">
+                <img src="images/Marcy_Gooberman_Hello_Alfred_1.png" alt="">
+                Hello Alfred
+            </a>
+        </article>
+
+        <!-- gyno -->
+        <article class="course illustration">
+            <a href="images/Marcy_Gooberman_tabu_2.jpg" class="shinybox illustration" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_2.jpg" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- suraj condom -->
+        <article class="course print illustration">
+            <a href="images/Marcy_Gooberman_Suraj_Patel_1.gif" class="shinybox illustration"
+                title="Suraj Patel for Congress">
+                <img src="images/Marcy_Gooberman_Suraj_Patel_1.gif" alt="">
+                Suraj Patel for Congress
+            </a>
+        </article>
+
+        <!-- hug me -->
+        <article class="course motion illustration">
+            <a href="images/Marcy_Gooberman_Blume_18.gif" class="shinybox illustration" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_18.gif" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- self care bag -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Blume_5.jpg" class="shinybox print" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_5.jpg" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- shopping tips -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Best_Kept_Secret_2.gif" class="shinybox social title=" Best Kept Secret">
+                <img src="images/Marcy_Gooberman_Best_Kept_Secret_2.gif" alt="">
+                Best Kept Secret
+            </a>
+        </article>
+
+        <!-- self care covid -->
+        <article class="course social illustration">
+            <a href="images/Marcy_Gooberman_Blume_14.png" class="shinybox social illustration" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_14.png" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- ballerina -->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_8.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_8.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- zora -->
+        <article class="course motion illustration">
+            <a href="images/Marcy_Gooberman_Mizo_2.gif" class="shinybox motion illustration" title="Mizo Productions">
+                <img src="images/Marcy_Gooberman_Mizo_2.gif" alt="">
+                Mizo Productions
+            </a>
+        </article>
+
+        <!-- larry -->
+        <article class="course motion illustration">
+            <a href="images/Marcy_Gooberman_Personal_1.gif" class="shinybox motion illustration" title="Personal Work">
+                <img src="images/Marcy_Gooberman_Personal_1.gif" alt="">
+                Personal Work
+            </a>
+        </article>
+
+        <!-- help people -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Blume_13.png" class="shinybox social" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_13.png" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- dolly riso -->
+        <article class="course illustration print">
+            <a href="images/Marcy_Gooberman_Personal_6.jpg" class="shinybox illustration print" title="Personal Work">
+                <img src="images/Marcy_Gooberman_Personal_6.jpg" alt="">
+                Personal Work
+            </a>
+        </article>
+
+        <!-- tshirt -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_Blume_6.jpg" class="shinybox print" title="Blume">
+                <img src="images/Marcy_Gooberman_Blume_6.jpg" alt="">
+                Blume
+            </a>
+        </article>
+
+        <!-- greenspace -->
+        <article class="course print">
+            <a href="images/Marcy_Gooberman_NYPR_2.png" class="shinybox print"
+                title="The Greene Space by NY Public Radio">
+                <img src="images/Marcy_Gooberman_NYPR_2.png" alt="">
+                The Greene Space by NY Public Radio
+            </a>
+        </article>
+
+        <!-- olson twins-->
+        <article class="course motion social">
+            <a href="images/Marcy_Gooberman_Cosmo_Snap_7.gif" class="shinybox motion social"
+                title="Cosmopolitan Snapchat Discover">
+                <img src="images/Marcy_Gooberman_Cosmo_Snap_7.gif" alt="">
+                Cosmopolitan Snapchat Discover
+            </a>
+        </article>
+
+        <!-- gravitatas -->
+        <article class="course branding">
+            <a href="images/Marcy_Gooberman_gravitatas_1.png" class="shinybox branding" title="Gravitatas">
+                <img src="images/Marcy_Gooberman_gravitatas_1.png" alt="">
+                Gravitatas
+            </a>
+        </article>
+
+        <!-- period pain -->
+        <article class="course illustration">
+            <a href="images/Marcy_Gooberman_tabu_3.jpg" class="shinybox illustration" title="tabú">
+                <img src="images/Marcy_Gooberman_tabu_3.jpg" alt="">
+                tabú
+            </a>
+        </article>
+
+        <!-- goob  -->
+        <article class="course web branding">
+            <a href="images/Marcy_Gooberman_Personal_7.gif" class="shinybox web branding" title="Personal Work">
+                <img src="images/Marcy_Gooberman_Personal_7.gif" alt="">
+                Personal Work
+            </a>
+        </article>
+
+        <!-- toilet paper -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_Hello_Alfred_3.gif" class="shinybox social" title="Hello Alfred">
+                <img src="images/Marcy_Gooberman_Hello_Alfred_3.gif" alt="">
+                Hello Alfred
+            </a>
+        </article>
+
+        <!-- oval office -->
+        <article class="course illustration motion">
+            <a href="images/Marcy_Gooberman_Cosmo_Sex_4.gif" class="shinybox illustration motion"
+                title="Cosmopolitan.com">
+                <img src="images/Marcy_Gooberman_Cosmo_Sex_4.gif" alt="">
+                Cosmopolitan.com
+            </a>
+        </article>
+
+        <!-- squat -->
+        <article class="course social motion illustration">
+            <a href="images/Marcy_Gooberman_WW_1.gif" class="shinybox social motion illustration"
+                title="Weight Watchers">
+                <img src="images/Marcy_Gooberman_WW_1.gif" alt="">
+                Weight Watchers
+            </a>
+        </article>
+
+        <!-- cardi b -->
+        <article class="course social">
+            <a href="images/Marcy_Gooberman_tabu_7.png" class="shinybox social title=" tabú">
+                <img src="images/Marcy_Gooberman_tabu_7.png" alt="">
+                tabú
+            </a>
+        </article>
+
+
+
+    </div>
+
+
 
     <footer>©2020 Marcy Gooberman. All Rights Reserved.</footer>
-    
-    <script
-  src="https://code.jquery.com/jquery-2.2.4.min.js"
-  integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
-  crossorigin="anonymous"></script>
 
-     
+    <script src="https://code.jquery.com/jquery-2.2.4.min.js"
+        integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+
+
     <script src="JS/jquery.shinybox.js"></script>
     <script src="JS/libs/imagesloaded.pkgd.min.js"></script>
     <script src="JS/libs/isotope.pkgd.min.js"></script>
     <script src="JS/isotope.settings.js"></script>
     <script type="text/javascript">
-            jQuery(function($) {
-                $(".shinybox").shinybox();
-            });
-            </script>    
+        jQuery(function ($) {
+            $(".shinybox").shinybox();
+        });
+    </script>
 
 </body>
 


### PR DESCRIPTION
In order to filter the shinybox results, I did the following:

- Added filter-specific classnames to child elements in the HTML, so that the shinybox.js file could grab the correct info without too much hassle
- In shinybox, I checked which filter term was active, and applied it as a filter to the list of items displayed by shinybox.