### PR TITLE
Filter shinybox minimal diff

### DIFF
--- a/JS/jquery.shinybox.js
+++ b/JS/jquery.shinybox.js
@@ -104,6 +104,10 @@
                     e.preventDefault();
                     e.stopPropagation();
 
+                    // check for currently selected filter and grab its classname
+                    var filters = $('.filter-item').filter('.checked')
+                    var filterTerm = filters.attr("data-filter")                    
+
                     self.ui && self.ui.destroy();
 
                     var $this = $(this);
@@ -122,7 +126,12 @@
                     if (relVal && relVal !== 'nofollow') {
                         $slideElements = $selectedElements.filter('[' + relType + '="' + relVal + '"]');
                     } else {
-                        $slideElements = $(selector);
+                        // check filter term (can be undefined) and apply it to ALSO filter shinybox
+                        if (filterTerm !== undefined) {
+                            $slideElements = $(selector + filterTerm);
+                        } else {
+                            $slideElements = $(selector);
+                        }
                     }
 
                     // Generate slides from DOM elements and initialize UI

--- a/index.html
+++ b/index.html
@@ -28,14 +28,14 @@
         <nav id="filter" class="filters">
             
             <ul class="filter-list" data-filter-group="subject">
-                <li><a href="javascript:void(0)" data-filter=".branding">Branding</a></li>
-                <li><a href="javascript:void(0)" data-filter=".social">Social Media</a></li>
-                <li><a href="javascript:void(0)" data-filter=".illustration">Illustration</a></li>
-                <li><a href="javascript:void(0)" data-filter=".print">Print</a></li>
+                <li><a href="javascript:void(0)" class="filter-item" data-filter=".branding">Branding</a></li>
+                <li><a href="javascript:void(0)" class="filter-item" data-filter=".social">Social Media</a></li>
+                <li><a href="javascript:void(0)" class="filter-item" data-filter=".illustration">Illustration</a></li>
+                <li><a href="javascript:void(0)" class="filter-item" data-filter=".print">Print</a></li>
                 
-                <li><a href="javascript:void(0)" data-filter=".motion">Motion Graphics</a></li>
+                <li><a href="javascript:void(0)" class="filter-item" data-filter=".motion">Motion Graphics</a></li>
                 
-                <li><a href="javascript:void(0)" data-filter=".web">Web</a></li>
+                <li><a href="javascript:void(0)" class="filter-item" data-filter=".web">Web</a></li>
                 
             </ul><!-- .subject -->
             
@@ -46,7 +46,7 @@
 
 <!-- period pandemic --><article class="course social">
                             <a href="images/Marcy_Gooberman_Blume_1.png"
-                                class="shinybox" 
+                                class="shinybox social" 
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_1.png" alt="">
                                 Blume
@@ -56,7 +56,7 @@
 
   <!-- suraj posters --><article class="course print">
                             <a href="images/Marcy_Gooberman_Suraj_Patel_3.jpg"
-                                class="shinybox" 
+                                class="shinybox print" 
                                 title="Suraj Patel for Congress">
                                 <img src="images/Marcy_Gooberman_Suraj_Patel_3.jpg" alt="">
                                 Suraj Patel for Congress
@@ -65,7 +65,7 @@
 
   <!-- marcy & peggy --><article class="course illustration">
                             <a href="images/Marcy_Gooberman_Personal_2.png"
-                                class="shinybox"                                 
+                                class="shinybox illustration"                                 
                                 title="Personal Work">      
                                 <img src="images/Marcy_Gooberman_Personal_2.png" alt="">
                                 Personal Work
@@ -74,7 +74,7 @@
 
        <!-- dog riso --><article class="course illustration print">
                             <a href="images/Marcy_Gooberman_Personal_5.jpg"
-                                class="shinybox"                                 
+                                class="shinybox illustration print"                                 
                                 title="Personal Work">
                                 <img src="images/Marcy_Gooberman_Personal_5.jpg" alt="">
                                 Personal Work
@@ -83,7 +83,7 @@
 
    <!-- one day left --><article class="course social">
                             <a href="images/Marcy_Gooberman_Best_Kept_Secret_1.gif"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Best Kept Secret">
                                 <img src="images/Marcy_Gooberman_Best_Kept_Secret_1.gif" alt="">
                                 Best Kept Secret
@@ -92,7 +92,7 @@
 
      <!-- flash sale --><article class="course social">
                             <a href="images/Marcy_Gooberman_Blume_2.gif"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_2.gif" alt="">
                                 Blume
@@ -101,7 +101,7 @@
 
       <!-- blume box --><article class="course motion illustration">
                             <a href="images/Marcy_Gooberman_Blume_3.gif"
-                                class="shinybox"
+                                class="shinybox motion illustration"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_3.gif" alt="">
                                 Blume
@@ -110,7 +110,7 @@
 
      <!-- foundation --><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_5.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_5.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -119,7 +119,7 @@
 
  <!-- back to school --><article class="course print illustration">
                             <a href="images/Marcy_Gooberman_Blume_4.jpg"
-                                class="shinybox"
+                                class="shinybox print illustration"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_4.jpg" alt="">
                                 Blume
@@ -128,7 +128,7 @@
 
    <!-- make me feel --><article class="course social">
                             <a href="images/Marcy_Gooberman_tabu_6.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_6.png" alt="">
                                 tabú
@@ -137,7 +137,7 @@
 
        <!-- crunches --><article class="course social motion illustration">
                             <a href="images/Marcy_Gooberman_WW_2.gif"
-                                class="shinybox"
+                                class="shinybox social motion illustration"
                                 title="Weight Watchers">
                                 <img src="images/Marcy_Gooberman_WW_2.gif" alt="">
                                 Weight Watchers
@@ -146,7 +146,7 @@
 
 <!-- m cyclists --><article class="course branding">
                             <a href="images/Marcy_Gooberman_Menstrual_Cyclists_1.png"
-                                class="shinybox"
+                                class="shinybox branding"
                                 title="Menstrual Cyclists">
                                 <img src="images/Marcy_Gooberman_Menstrual_Cyclists_1.png" alt="">
                                 Menstrual Cyclists
@@ -155,7 +155,7 @@
 
           <!-- iskra --><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_6.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_6.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -164,7 +164,7 @@
 
       <!-- dolly vid --><article class="course motion">
                             <a href="images/Marcy_Gooberman_NYPR_1.gif"
-                                class="shinybox"
+                                class="shinybox motion"
                                 title="Dolly Parton's America by NY Public Radio">
                                 <img src="images/Marcy_Gooberman_NYPR_1.gif" alt="">
                                 Dolly Parton's America by NY Public Radio
@@ -173,7 +173,7 @@
 
   <!-- alyson stoner --><article class="course social">
                             <a href="images/Marcy_Gooberman_tabu_5.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_5.png" alt="">
                                 tabú
@@ -182,7 +182,7 @@
                         
      <!-- dumto logo --><article class="course branding">
                             <a href="images/Marcy_Gooberman_DUMTO_1.png"
-                                class="shinybox"
+                                class="shinybox branding"
                                 title="DUMTO Brooklyn">
                                 <img src="images/Marcy_Gooberman_DUMTO_1.png" alt="">
                                 DUMTO Brooklyn
@@ -190,7 +190,7 @@
                         </article>                                                                      
   <!-- school photos --><article class="course social">
                             <a href="images/Marcy_Gooberman_Blume_12.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_12.png" alt="">
                                 Blume
@@ -199,7 +199,7 @@
 
  <!-- subway posters --><article class="course print">
                             <a href="images/Marcy_Gooberman_Suraj_Patel_2.jpg"
-                                class="shinybox"
+                                class="shinybox print"
                                 title="Suraj Patel for Congress">
                                 <img src="images/Marcy_Gooberman_Suraj_Patel_2.jpg" alt="">
                                 Suraj Patel for Congress
@@ -208,7 +208,7 @@
 
   <!-- exercise ball --><article class="course illustration motion">
                             <a href="images/Marcy_Gooberman_Cosmo_Sex_2.gif"
-                                class="shinybox"
+                                class="shinybox illustration motion"
                                 title="Cosmopolitan.com">
                                 <img src="images/Marcy_Gooberman_Cosmo_Sex_2.gif" alt="">
                                 Cosmopolitan.com
@@ -217,7 +217,7 @@
 
        <!-- stickers --><article class="course print illustration">
                             <a href="images/Marcy_Gooberman_Blume_7.jpg"
-                                class="shinybox"
+                                class="shinybox print illustration"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_7.jpg" alt="">
                                 Blume
@@ -226,7 +226,7 @@
 
          <!-- uterus --><article class="course motion illustration">
                             <a href="images/Marcy_Gooberman_Blume_8.gif"
-                                class="shinybox"
+                                class="shinybox motion illustration"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_8.gif" alt="">
                                 Blume
@@ -235,7 +235,7 @@
 
 <!-- inside brochure --><article class="course print">
                             <a href="images/Marcy_Gooberman_Hello_Alfred_2.png"
-                                
+                                class="shinybox print"
                                 title="Hello Alfred">
                                 <img src="images/Marcy_Gooberman_Hello_Alfred_2.png" alt="">
                                 Hello Alfred
@@ -244,7 +244,7 @@
 
             <!-- iud --><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_3.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_3.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -253,7 +253,7 @@
 
 <!-- mini daydreamer --><article class="course print">
                             <a href="images/Marcy_Gooberman_Blume_9.jpg"
-                                class="shinybox"
+                                class="shinybox print"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_9.jpg" alt="">
                                 Blume
@@ -262,7 +262,7 @@
 
        <!-- lipstick --><article class="course illustration">
                             <a href="images/Marcy_Gooberman_tabu_4.jpg"
-                                class="shinybox"
+                                class="shinybox illustration"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_4.jpg" alt="">
                                 tabú
@@ -271,7 +271,7 @@
 
        <!-- fts logo --><article class="course branding">
                             <a href="images/Marcy_Gooberman_FTS_1.png"
-                                class="shinybox"
+                                class="shinybox branding"
                                 title="Friend That Spends">
                                 <img src="images/Marcy_Gooberman_FTS_1.png" alt="">
                                 Friend That Spends
@@ -280,7 +280,7 @@
 
    <!-- tarana burke --><article class="course social">
                             <a href="images/Marcy_Gooberman_tabu_9.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_9.png" alt="">
                                 tabú
@@ -289,7 +289,7 @@
 
       <!-- 24 states --><article class="course social">
                             <a href="images/Marcy_Gooberman_Blume_10.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_10.png" alt="">
                                 Blume
@@ -298,7 +298,7 @@
 
        <!-- butthole --><article class="course illustration motion">
                             <a href="images/Marcy_Gooberman_Cosmo_Sex_1.gif"
-                                class="shinybox"
+                                class="shinybox illustration motion"
                                 title="Cosmopolitan.com">
                                 <img src="images/Marcy_Gooberman_Cosmo_Sex_1.gif" alt="">
                                 Cosmopolitan.com
@@ -307,7 +307,7 @@
 
            <!-- mimi --><article class="course motion illustration">
                             <a href="images/Marcy_Gooberman_Mizo_1.gif"
-                                class="shinybox"
+                                class="shinybox motion illustration"
                                 title="Mizo Productions">
                                 <img src="images/Marcy_Gooberman_Mizo_1.gif" alt="">
                                 Mizo Productions                            
@@ -316,7 +316,7 @@
 
     <!-- highlighter --><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_4.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_4.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -325,7 +325,7 @@
 
  <!-- sexual assault --><article class="course social">
                             <a href="images/Marcy_Gooberman_Blume_11.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_11.png" alt="">
                                 Blume
@@ -334,7 +334,7 @@
 
           <!-- dumto --><article class="course illustration print">
                             <a href="images/Marcy_Gooberman_DUMTO_2.png"
-                                class="shinybox"
+                                class="shinybox illustration print"
                                 title="DUMTO Brooklyn">
                                 <img src="images/Marcy_Gooberman_DUMTO_2.png" alt="">
                                 DUMTO Brooklyn
@@ -343,7 +343,7 @@
 
        <!-- wishlist --><article class="course social">
                             <a href="images/Marcy_Gooberman_Best_Kept_Secret_3.gif"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Best Kept Secret">
                                 <img src="images/Marcy_Gooberman_Best_Kept_Secret_3.gif" alt="">
                                 Best Kept Secret
@@ -352,7 +352,7 @@
 
           <!-- whirl --><article class="course print">
                             <a href="images/Marcy_Gooberman_Blume_15.jpg"
-                                class="shinybox"
+                                class="shinybox print"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_15.jpg" alt="">
                                 Blume
@@ -361,7 +361,7 @@
 
       <!-- halloween --><article class="course illustration motion">
                             <a href="images/Marcy_Gooberman_Cosmo_Sex_3.gif"
-                                class="shinybox"
+                                class="shinybox illustration  motion"
                                 title="Cosmopolitan.com">
                                 <img src="images/Marcy_Gooberman_Cosmo_Sex_3.gif" alt="">
                                 Cosmopolitan.com
@@ -370,7 +370,7 @@
 
       <!-- naked man --><article class="course illustration">
                             <a href="images/Marcy_Gooberman_tabu_1.jpg"
-                                class="shinybox"
+                                class="shinybox illustration"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_1.jpg" alt="">
                                 tabú
@@ -379,7 +379,7 @@
 
          <!-- airhug --><article class="course print">
                             <a href="images/Marcy_Gooberman_Blume_16.jpg"
-                                class="shinybox"
+                                class="shinybox print"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_16.jpg" alt="">
                                 Blume
@@ -388,7 +388,7 @@
 
          <!-- selfie --><article class="course illustration">
                             <a href="images/Marcy_Gooberman_Personal_3.jpg"
-                            class="shinybox"
+                            class="shinybox illustration"
                             title="Personal Work">
                             <img src="images/Marcy_Gooberman_Personal_3.jpg" alt="">
                                 Personal Work
@@ -397,7 +397,7 @@
 
       <!-- equal pay --><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_1.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_1.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -406,7 +406,7 @@
 
           <!-- disco --><article class="course illustration motion">
                             <a href="images/Marcy_Gooberman_Cosmo_Sex_5.gif"
-                                class="shinybox"
+                                class="shinybox illustration motion"
                                 title="Cosmopolitan.com">
                                 <img src="images/Marcy_Gooberman_Cosmo_Sex_5.gif" alt="">
                                 Cosmopolitan.com
@@ -415,7 +415,7 @@
 
     <!-- lena waithe --><article class="course social">
                             <a href="images/Marcy_Gooberman_tabu_8.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_8.png" alt="">
                                 tabú
@@ -424,7 +424,7 @@
 
  <!-- back to school --><article class="course web">
                             <a href="images/Marcy_Gooberman_Blume_19.png"
-                                class="shinybox"
+                                class="shinybox web"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_19.png" alt="">
                                 Blume
@@ -433,7 +433,7 @@
 
 <!-- lazy girl hacks --><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_2.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_2.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -442,7 +442,7 @@
 
         <!-- cloud 9 --><article class="course motion illustration">
                             <a href="images/Marcy_Gooberman_Blume_17.gif"
-                                class="shinybox"
+                                class="shinybox motion illustration"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_17.gif" alt="">
                                 Blume
@@ -451,7 +451,7 @@
 
  <!-- brochure cover --><article class="course print">
                             <a href="images/Marcy_Gooberman_Hello_Alfred_1.png"
-                                class="shinybox"
+                                class="shinybox print"
                                 title="Hello Alfred">
                                 <img src="images/Marcy_Gooberman_Hello_Alfred_1.png" alt="">
                                 Hello Alfred
@@ -460,7 +460,7 @@
 
            <!-- gyno --><article class="course illustration">
                             <a href="images/Marcy_Gooberman_tabu_2.jpg"
-                                class="shinybox"
+                                class="shinybox illustration"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_2.jpg" alt="">
                                 tabú
@@ -469,7 +469,7 @@
 
    <!-- suraj condom --><article class="course print illustration">
                             <a href="images/Marcy_Gooberman_Suraj_Patel_1.gif"
-                                class="shinybox"
+                                class="shinybox print illustration"
                                 title="Suraj Patel for Congress">
                                 <img src="images/Marcy_Gooberman_Suraj_Patel_1.gif" alt="">
                                 Suraj Patel for Congress
@@ -478,7 +478,7 @@
 
          <!-- hug me --><article class="course motion illustration">
                             <a href="images/Marcy_Gooberman_Blume_18.gif"
-                                class="shinybox"
+                                class="shinybox motion illustration"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_18.gif" alt="">
                                 Blume
@@ -487,7 +487,7 @@
 
   <!-- self care bag --><article class="course print">
                            <a href="images/Marcy_Gooberman_Blume_5.jpg"
-                                class="shinybox"
+                                class="shinybox print"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_5.jpg" alt="">
                                 Blume
@@ -496,7 +496,7 @@
 
   <!-- shopping tips --><article class="course social">
                             <a href="images/Marcy_Gooberman_Best_Kept_Secret_2.gif"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Best Kept Secret">
                                 <img src="images/Marcy_Gooberman_Best_Kept_Secret_2.gif" alt="">
                                 Best Kept Secret
@@ -505,7 +505,7 @@
 
 <!-- self care covid --><article class="course social illustration">
                             <a href="images/Marcy_Gooberman_Blume_14.png"
-                                class="shinybox"
+                                class="shinybox social illustration"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_14.png" alt="">
                                 Blume
@@ -514,7 +514,7 @@
 
       <!-- ballerina --><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_8.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_8.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -523,7 +523,7 @@
 
            <!-- zora --><article class="course motion illustration">
                             <a href="images/Marcy_Gooberman_Mizo_2.gif"
-                                class="shinybox"
+                                class="shinybox motion illustration"
                                 title="Mizo Productions">
                                 <img src="images/Marcy_Gooberman_Mizo_2.gif" alt="">
                                 Mizo Productions                            
@@ -532,7 +532,7 @@
 
           <!-- larry --><article class="course motion illustration">
                             <a href="images/Marcy_Gooberman_Personal_1.gif"
-                                class="shinybox"
+                                class="shinybox motion illustration"
                                 title="Personal Work">
                                 <img src="images/Marcy_Gooberman_Personal_1.gif" alt="">
                                 Personal Work
@@ -541,7 +541,7 @@
 
     <!-- help people --><article class="course social">
                             <a href="images/Marcy_Gooberman_Blume_13.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_13.png" alt="">
                                 Blume
@@ -550,7 +550,7 @@
 
      <!-- dolly riso --><article class="course illustration print">
                             <a href="images/Marcy_Gooberman_Personal_6.jpg"
-                                class="shinybox"
+                                class="shinybox illustration print"
                                 title="Personal Work">
                                 <img src="images/Marcy_Gooberman_Personal_6.jpg" alt="">
                                 Personal Work
@@ -559,7 +559,7 @@
 
          <!-- tshirt --><article class="course print">
                             <a href="images/Marcy_Gooberman_Blume_6.jpg"
-                                class="shinybox"
+                                class="shinybox print"
                                 title="Blume">
                                 <img src="images/Marcy_Gooberman_Blume_6.jpg" alt="">
                                 Blume
@@ -568,7 +568,7 @@
 
      <!-- greenspace --><article class="course print">
                             <a href="images/Marcy_Gooberman_NYPR_2.png"
-                                class="shinybox"
+                                class="shinybox  print"
                                 title="The Greene Space by NY Public Radio">
                                 <img src="images/Marcy_Gooberman_NYPR_2.png" alt="">
                                 The Greene Space by NY Public Radio
@@ -577,7 +577,7 @@
 
       <!-- olson twins--><article class="course motion social">
                             <a href="images/Marcy_Gooberman_Cosmo_Snap_7.gif"
-                                class="shinybox"
+                                class="shinybox motion social"
                                 title="Cosmopolitan Snapchat Discover">
                                 <img src="images/Marcy_Gooberman_Cosmo_Snap_7.gif" alt="">
                                 Cosmopolitan Snapchat Discover
@@ -586,7 +586,7 @@
 
      <!-- gravitatas --><article class="course branding">
                             <a href="images/Marcy_Gooberman_gravitatas_1.png"
-                                class="shinybox"
+                                class="shinybox branding"
                                 title="Gravitatas">
                                 <img src="images/Marcy_Gooberman_gravitatas_1.png" alt="">
                                 Gravitatas
@@ -595,7 +595,7 @@
 
     <!-- period pain --><article class="course illustration">
                             <a href="images/Marcy_Gooberman_tabu_3.jpg"
-                                class="shinybox"
+                                class="shinybox illustration"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_3.jpg" alt="">
                                 tabú
@@ -604,7 +604,7 @@
 
        <!-- goob  --><article class="course web branding">
                             <a href="images/Marcy_Gooberman_Personal_7.gif"
-                                class="shinybox"
+                                class="shinybox web branding"
                                 title="Personal Work">
                                 <img src="images/Marcy_Gooberman_Personal_7.gif" alt="">
                                 Personal Work
@@ -613,7 +613,7 @@
 
 <!-- toilet paper --><article class="course social">
                             <a href="images/Marcy_Gooberman_Hello_Alfred_3.gif"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="Hello Alfred">
                                 <img src="images/Marcy_Gooberman_Hello_Alfred_3.gif" alt="">
                                 Hello Alfred
@@ -622,7 +622,7 @@
     
 <!-- oval office --><article class="course illustration motion">
                             <a href="images/Marcy_Gooberman_Cosmo_Sex_4.gif"
-                                class="shinybox"
+                                class="shinybox illustration motion"
                                 title="Cosmopolitan.com">
                                 <img src="images/Marcy_Gooberman_Cosmo_Sex_4.gif" alt="">
                                 Cosmopolitan.com
@@ -631,7 +631,7 @@
 
           <!-- squat --><article class="course social motion illustration">
                             <a href="images/Marcy_Gooberman_WW_1.gif"
-                                class="shinybox"
+                                class="shinybox social motion illustration"
                                 title="Weight Watchers">
                                 <img src="images/Marcy_Gooberman_WW_1.gif" alt="">
                                 Weight Watchers
@@ -640,7 +640,7 @@
 
         <!-- cardi b --><article class="course social">
                             <a href="images/Marcy_Gooberman_tabu_7.png"
-                                class="shinybox"
+                                class="shinybox social"
                                 title="tabú">
                                 <img src="images/Marcy_Gooberman_tabu_7.png" alt="">
                                 tabú


### PR DESCRIPTION
In order to filter the shinybox results, I did the following:

- Added filter-specific classnames to child elements in the HTML, so that the shinybox.js file could grab the correct info without too much hassle
- In shinybox, I checked which filter term was active, and applied it as a filter to the list of items displayed by shinybox.

This PR is identical to my first, declined one, but with no code formatting to make the diff more legible.